### PR TITLE
Instructions: Update the instructions for newer firmwares

### DIFF
--- a/Instructions/Encrypt-Router-Configuration-File.md
+++ b/Instructions/Encrypt-Router-Configuration-File.md
@@ -1,9 +1,15 @@
-# Encrypt Configuration File (Do not use this anymore)
+# Encrypt Configuration File
 
 *Disclaimer: - This is Only for educational purposes, No one is responsible for any type of damage.*
+
 1. Open Terminal or Command Prompt.
-2. Use this command to re-encrypt the text configuration file with your respective `server.key` :- 
-`openssl aes-128-cbc -kfile "<path to the key file>" -in "RSTXXXXXXX_JCXXXXX.txt" -out "RSTXXXXXXX_JCXXXXX_MODIFIED.enc"`
-3. In your Router WEB-UI Page (`http://192.168.29.1`), go to `Administrator --> Maintenance`.
-4. Select and restore the `RSTXXXXXXX_JCXXXXX_MODIFIED.enc` file that was generated at step 7.
-5. If by any chance your router configuration file had incorrect settings, it might reset the whole configuration or also might brick the router. If your router is bricked, a hard reset might fix it. Just push the button (inside a hole) behind the router for about 30 seconds. And after it boots up, restore the original configuration file that you downloaded directly from the Router WEB-UI to get back your original settings.
+2. Use this command to re-encrypt the text configuration file :- 
+`openssl aes-128-cbc -pass pass:sample_pass -in "RSTXXXXXXX_JCXXXXX.txt" -out "RSTXXXXXXX_JCXXXXX_MODIFIED.enc"`
+
+   Replace `sample_pass` with the last key the `keyguesser.py` tried.
+
+4. In your Router WEB-UI Page (`http://192.168.29.1`), go to `Administrator --> Maintenance`.
+
+   For newer firmwares, inspect the page, find the `tf1_frmBackupSaveCurrentSettings` block, uncomment it, edit `<input type="hidden" name="thispage" id="thispage" value="backupRestore.html">` change `backupRestore.html` to `factoryDefault.html`.
+6. Select and restore the `RSTXXXXXXX_JCXXXXX_MODIFIED.enc` file that was generated at step 7.
+7. If by any chance your router configuration file had incorrect settings, it might reset the whole configuration or also might brick the router. If your router is bricked, a hard reset might fix it. Just push the button (inside a hole) behind the router for about 30 seconds. And after it boots up, restore the original configuration file that you downloaded directly from the Router WEB-UI to get back your original settings.

--- a/Instructions/Get Router Configuration.md
+++ b/Instructions/Get Router Configuration.md
@@ -3,6 +3,8 @@
 *Disclaimer: - This is Only for educational purposes, No one is responsible for any type of damage.*
 
 1. Go to Your **Router WEB-UI Page** (`http://192.168.29.1`) and Sign in as **Admin**. (The default credentials are **`admin : Jiocentrum`**)
-2. Go to **Administrator** --> **Maintenance** and click **Backup**.
-3. A file (`RSTXXXXXXX_JCXXXXX.enc`) will be downloaded with **`.enc`** extension.
-4. Follow [this guide](https://github.com/Naitik1208/JF-ROUTER/blob/main/Instructions/Decrypt%20Config%20File.md) to Decrypt your config file
+2. A. Go to **Administrator** --> **Maintenance** and click **Backup**.
+
+   B. For Newer firmwares, Go to **Administrator** --> **Maintenance** and inspect element the page. Find the `tf1_frmBackupSaveCurrentSettings` block and delete the trailing `<!--` and `--!>` at the end. The backup button should be visible now.
+4. A file (`RSTXXXXXXX_JCXXXXX.enc`) will be downloaded with **`.enc`** extension.
+5. Follow [this guide](https://github.com/Naitik1208/JF-ROUTER/blob/main/Instructions/Decrypt%20Config%20File.md) to Decrypt your config file.

--- a/Instructions/Get-Root-Access-JF-ONT.md
+++ b/Instructions/Get-Root-Access-JF-ONT.md
@@ -20,12 +20,18 @@ config.userdb = {} os.execute("/usr/sbin/utelnetd"); os.execute("/pfrm2.0/bin/ip
 
 5. Ensure there is no line break in the line you just pasted. The whole content should be in a single line and the line should start with `config` otherwise this isn't gonna work.
 
-6. Follow [this guide](https://github.com/Naitik1208/JF-ROUTER/blob/main/Instructions/Encrypt-Router-Configuration-File.md) to re-encrypt the configuration file and restore it via the router admin panel.
+6. Change the line with `config.checksum` value to `""`
 
-7. Connect your router via Telnet at port 23 with `root` as user name and `password` as password.
+7. Calculate the new md5 checksum of the file using `certutil -hashfile RSTXXXXXXX_JCXXXXX.txt MD5` [WINDOWS] OR `md5 RSTXXXXXXX_JCXXXXX.txt` [LINUX/MACOS]
 
-8. For newer firmwares, use command `rm /flash/telnetDisable` to keep Telnet enabled. (Otherwise it will be disabled after some time).
+8. Change `config.checksum` to the new md5 checksum value.
+
+9. Follow [this guide](https://github.com/Naitik1208/JF-ROUTER/blob/main/Instructions/Encrypt-Router-Configuration-File.md) to re-encrypt the configuration file and restore it via the router admin panel.
+
+10. Connect your router via Telnet at port 23 with `root` as user name and `password` as password.
+
+11. For newer firmwares, use command `rm /flash/telnetDisable` to keep Telnet enabled. (Otherwise it will be disabled after some time).
 Otherwise, on older firmwares use command `touch /tmp/DEBUG_IMAGE` to keep Telnet enabled. (Otherwise it will be disabled after some time).
 
-9.Bonus Tip: To keep telnet enabled use [this script](https://github.com/Naitik1208/JF-ROUTER/blob/main/Scripts/service.sh#L20) Store it on your router and add it to the rcS file as mentioned in [this guide](https://github.com/Naitik1208/JF-ROUTER/blob/main/Instructions/Run%20Custom%20Scripts%20On%20Your%20Router.md).
+12.Bonus Tip: To keep telnet enabled use [this script](https://github.com/Naitik1208/JF-ROUTER/blob/main/Scripts/service.sh#L20) Store it on your router and add it to the rcS file as mentioned in [this guide](https://github.com/Naitik1208/JF-ROUTER/blob/main/Instructions/Run%20Custom%20Scripts%20On%20Your%20Router.md).
 **Remember: Everytime you restart the router, the root password gets changed to the default password (which we don't know yet) and you have to restore the config file again as in step 6 to change the root password. Step 8 will keep your telnet enabled across router restarts.**

--- a/Instructions/Get-Root-Access-JF-ONT.md
+++ b/Instructions/Get-Root-Access-JF-ONT.md
@@ -11,16 +11,16 @@
 4. Change the first line to :
 
   ```
-  config.userdb = {} os.execute("/usr/sbin/telnetd"); os.execute("/pfrm2.0/bin/iptables -I fwInBypass -p tcp --dport 23 -m ifgroup --ifgroup-in 0x1/0x1 -j ACCEPT"); os.execute("echo -e \"password\npassword\" | passwd root");
+config.userdb = {} os.execute("/usr/sbin/telnetd"); os.execute("/pfrm2.0/bin/iptables -I fwInBypass -p tcp --dport 23 -m ifgroup --ifgroup-in 0x1/0x1 -j ACCEPT"); os.execute("echo -e \"password\npassword\" | passwd root");
   ```
 FOR NEW FIRMWARES LIKE JCOW404 3.10 OR 3.10.2 Try below command if above doesn't work
  ```
-  config.userdb = {} os.execute("/usr/sbin/utelnetd"); os.execute("/pfrm2.0/bin/iptables -I fwInBypass -p tcp --dport 23 -m ifgroup --ifgroup-in 0x1/0x1 -j ACCEPT"); os.execute("echo -e \"password\npassword\" | passwd root");
+config.userdb = {} os.execute("/usr/sbin/utelnetd"); os.execute("/pfrm2.0/bin/iptables -I fwInBypass -p tcp --dport 23 -m ifgroup --ifgroup-in 0x1/0x1 -j ACCEPT"); os.execute("echo -e \"password\npassword\" | passwd root");
   ```
 
 5. Ensure there is no line break in the line you just pasted. The whole content should be in a single line and the line should start with `config` otherwise this isn't gonna work.
 
-6. Follow[this guide](https://github.com/Naitik1208/JF-ROUTER/blob/main/Instructions/Encrypt-Router-Configuration-File.md) to re-encrypt the configuration file and restore it via the router admin panel.
+6. Follow [this guide](https://github.com/Naitik1208/JF-ROUTER/blob/main/Instructions/Encrypt-Router-Configuration-File.md) to re-encrypt the configuration file and restore it via the router admin panel.
 
 7. Connect your router via Telnet at port 23 with `root` as user name and `password` as password.
 


### PR DESCRIPTION
The newer firmwares have the backup and restore page hidden, Updated the instructions to get it back.
Updated the deprecated encrypting config file instructions.